### PR TITLE
completed the network architecture

### DIFF
--- a/model.py
+++ b/model.py
@@ -3,8 +3,9 @@ import torch.nn as nn
 
 # TODO
 class DQNNet(nn.Module):
-    def __init__(self):
+    def __init__(self, num_of_actions):
         super(DQNNet, self).__init__()
+        self.num_of_actions = num_of_actions
 
         # images should be preprocessed (extract luminance channel from RGB channels) by φ defined in the paper.
 
@@ -27,7 +28,7 @@ class DQNNet(nn.Module):
         self.fc1 = nn.Linear(in_features=3136, out_features=512)
 
         # in: (512, ) - out: (7, )
-        self.fc2 = nn.Linear(in_features=512, out_features=7)
+        self.fc2 = nn.Linear(in_features=512, out_features=num_of_actions)
 
     def forward(self, x):
         x = self.conv1(x)


### PR DESCRIPTION
The architecture from the paper has been copied into `model.py` inside the class **DQNNet**. 
Notes:
1. I have considered the transformed images inputted into the network to be of shape (4, 84, 84). _(4 as stacking frames)_
2. Flattening inside `forward` need to be checked for the following potential issues:
2.1. Maybe the architecture in the paper don't mean to have a flattening after the last, fully connected hidden layer. 
2.2. I have assumed that the data (`x`) is as mini-batches inside `forward` so we shouldn't need to apply flattening across all dimensions (specifically we need to retain the first dimension, 0). So if the data (`x`) is sent as single images, we would need to apply flattening across all of the dimensions. i.e. have the following structure: 
```python
x = nn.Flatten(start_dim=0, end_dim=-1)
```