### PR TITLE
Add evaluation

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,21 @@
+import torch
+
+
+def evaluate(env, agent, device, games_count=10):
+    scores = []
+    for i in range(games_count):
+        obs, info = env.reset()
+        done = False
+        total_reward = 0
+
+        while not done:
+            action_index = agent.choose_action(torch.tensor(obs).unsqueeze(0).to(device), eps=0.05)
+
+            obs, reward, done, truncated, info = env.step(action_index)
+            total_reward += reward
+
+        scores.append(total_reward)
+
+    mean_scores = sum(scores)/len(scores)
+
+    print(f"Mean score: {mean_scores:.1f}")

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ import torch
 
 from agent import Agent
 from wrappers import AtariImage, ClipReward
+from eval import evaluate
 
 def plot_logs(game_id, total_interactions, episode_cnt, history_of_total_losses, history_of_total_rewards):
     fig, axs = plt.subplots(1, 2, figsize=(10, 5))
@@ -63,6 +64,7 @@ history_of_total_rewards = []
 episode_cnt = 0
 num_of_last_episodes_to_avg = 100
 log_display_step = 10000
+eval_cycle = 50000
 
 print(f'Starting the Training...')
 while total_interactions < max_total_interactions: 
@@ -104,6 +106,8 @@ while total_interactions < max_total_interactions:
 
             agent.save_model(f'saved_models/agent_it_{total_interactions}.pt')
 
+        if (total_interactions % eval_cycle and total_interactions > 0) == 0:
+            evaluate(wrapped_env, agent, device)
 
     # logging (accumulated over all episodes)
     history_of_total_losses.append(episode_total_loss)


### PR DESCRIPTION
Add a function to evaluate the agent while training. 
During the training, the agent doesn't follow a greedy policy and therefore the action it takes are not the optimal ones according to the policy. What we do is after each 50k frames we evaluate the agent on 10 games with a low epsilon and print the mean of the total rewards.