### PR TITLE
Wrap up of the last best setting we had on aug 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
-saved_models/
-plots/
+*best_checkpoints/
+*training_checkpoints/
+*training_log_plots/

--- a/agent.py
+++ b/agent.py
@@ -1,11 +1,6 @@
 import random
 import torch
-import torch.nn as nn
-import torch
-import torch.optim as optim
 import torch.nn.functional as F
-import numpy as np
-import copy
 
 from model import DQNNet
 from memory import Memory

--- a/init_dirs.py
+++ b/init_dirs.py
@@ -1,0 +1,33 @@
+import os
+
+def create_proj_dirs(game_id):
+    proj_dir_path = f'{game_id}_files/'
+    plots_dirname = f'{proj_dir_path}training_log_plots/'
+    training_checkpoints_dirname = f'{proj_dir_path}training_checkpoints/'
+    best_checkpoints_dirname = f'{proj_dir_path}best_checkpoints/'
+
+    if not os.path.exists(proj_dir_path):
+        os.makedirs(proj_dir_path)
+        print(f"Directory '{proj_dir_path}' created!")
+    else:
+        print(f"Directory '{proj_dir_path}' already exists!")
+
+    if not os.path.exists(plots_dirname):
+        os.makedirs(plots_dirname)
+        print(f"Directory '{plots_dirname}' created!")
+    else:
+        print(f"Directory '{plots_dirname}' already exists!")
+
+    if not os.path.exists(training_checkpoints_dirname):
+        os.makedirs(training_checkpoints_dirname)
+        print(f"Directory '{training_checkpoints_dirname}' created!")
+    else:
+        print(f"Directory '{training_checkpoints_dirname}' already exists!")
+    
+    if not os.path.exists(best_checkpoints_dirname):
+        os.makedirs(best_checkpoints_dirname)
+        print(f"Directory '{best_checkpoints_dirname}' created!")
+    else:
+        print(f"Directory '{best_checkpoints_dirname}' already exists!")
+
+    return plots_dirname, training_checkpoints_dirname, best_checkpoints_dirname

--- a/model.py
+++ b/model.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 # TODO

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 Pillow
 gymnasium
 ale-py
+numpy

--- a/test.py
+++ b/test.py
@@ -1,6 +1,5 @@
 import argparse
 import torch
-import numpy as np
 import gymnasium as gym
 from gymnasium.wrappers import TimeLimit
 from agent import Agent

--- a/test.py
+++ b/test.py
@@ -1,6 +1,8 @@
 import argparse
 import torch
 import gymnasium as gym
+import ale_py
+gym.register_envs(ale_py) # register the Atari environments
 from gymnasium.wrappers import TimeLimit
 from agent import Agent
 from wrappers import AtariImage, ClipReward, FireResetWithoutEpisodicLife, FireResetWithEpisodicLife, EpisodicLifeEnv, BreakoutActionTransform

--- a/test.py
+++ b/test.py
@@ -13,12 +13,11 @@ def test_model(model_path, env_name, total_games=3, num_of_lives_in_each_game=1,
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
     num_of_lives_in_each_game = 5
-    env = gym.make(id=game_id, frameskip=1)
+    env = gym.make(id=game_id, render_mode='human')
     wrappers_lst = [(EpisodicLifeEnv, {}), 
                     (FireResetWithEpisodicLife, {}), 
                     (ClipReward, {}), 
                     (AtariImage, {'image_shape':(84, 84), 'frame_skip': 4}), 
-                    (BreakoutActionTransform, {}),
                     (TimeLimit, {'max_episode_steps': 10000})] # each stack of frames is counted once
     wrapped_env = env
     for wrapper, kwargs in wrappers_lst:

--- a/train.py
+++ b/train.py
@@ -77,8 +77,7 @@ history_of_total_losses = []
 history_of_total_rewards = []
 episode_cnt = 0
 using_episodic_life = EpisodicLifeEnv in [t[0] for t in wrappers_lst]
-scaling_factor = num_of_lives_in_each_game if using_episodic_life else 1
-num_of_last_episodes_to_avg = 100 * scaling_factor
+num_of_last_episodes_to_avg = 100
 log_display_step = 10000
 start_time = time.time()
 

--- a/train.py
+++ b/train.py
@@ -3,12 +3,8 @@ import ale_py
 gym.register_envs(ale_py) # register the Atari environments
 from gymnasium.wrappers import TimeLimit
 
-import random
 import numpy as np
-import matplotlib.pyplot as plt
-import seaborn as sns
 import torch
-import os
 import time
 import math
 

--- a/train.py
+++ b/train.py
@@ -112,7 +112,7 @@ while total_interactions < max_total_interactions:
  
 
         if (total_interactions % log_display_step) == 0 and (episode_cnt >= num_of_last_episodes_to_avg):
-            print(f'<------- Displaying logs at the frame {total_interactions}, episode {episode_cnt} ------->')
+            print(f'<------- Displaying logs at the iteration {total_interactions}, episode {episode_cnt} ------->')
 
             # printing training logs
             print(f'Training logs over the last {num_of_last_episodes_to_avg} episodes:')
@@ -120,8 +120,8 @@ while total_interactions < max_total_interactions:
             avg_reward_of_last_episodes = np.mean(history_of_total_rewards[-num_of_last_episodes_to_avg:])
             std_loss_of_last_episodes = np.std(history_of_total_losses[-num_of_last_episodes_to_avg:])
             std_reward_of_last_episodes = np.std(history_of_total_rewards[-num_of_last_episodes_to_avg:])
-            print(f'Loss: mean:{avg_loss_of_last_episodes:.4f}, std:{std_loss_of_last_episodes:.4f}')
-            print(f'Reward: mean:{avg_reward_of_last_episodes:.4f}, std:{std_reward_of_last_episodes:.4f}')
+            print(f'Loss: {avg_loss_of_last_episodes:.4f} ± {std_loss_of_last_episodes:.4f}')
+            print(f'Reward: {avg_reward_of_last_episodes:.4f} ± {std_reward_of_last_episodes:.4f}')
 
             # printing evaluation logs            
             eval_mean, eval_var = evaluate(wrapped_env, agent, device, num_of_lives_in_each_game=num_of_lives_in_each_game, using_episodic_life=using_episodic_life)
@@ -131,7 +131,7 @@ while total_interactions < max_total_interactions:
 
             # TODO - updating the best model according to mean evaluation scores and saving
             if eval_mean > best_eval_mean:
-                print(f"Changing best model: evaluation reward mean improved by {eval_mean - best_eval_mean:.4f}! (showing up to 4 decimal places)")
+                print(f"Changing best model: evaluation mean reward improved by {eval_mean - best_eval_mean:.4f}!")
                 best_eval_mean = eval_mean
                 agent.save_model(f'{checkpoints_dir_path}best_model_it_{total_interactions}.pt')
 

--- a/train.py
+++ b/train.py
@@ -28,7 +28,7 @@ plots_dirname, training_checkpoints_dirname, best_checkpoints_dirname = create_p
 
 # cofiguration of the environment
 num_of_lives_in_each_game = 5
-env = gym.make(id=game_id, frameskip=1)
+env = gym.make(id=game_id)
 wrappers_lst = [(EpisodicLifeEnv, {}), 
                 (FireResetWithEpisodicLife, {}), 
                 (ClipReward, {}), 

--- a/train.py
+++ b/train.py
@@ -111,7 +111,7 @@ while total_interactions < max_total_interactions:
         episode_total_reward += reward
  
 
-        if (total_interactions % log_display_step) == 0 and (total_interactions > 0) and (episode_cnt >= num_of_last_episodes_to_avg):
+        if (total_interactions % log_display_step) == 0 and (episode_cnt >= num_of_last_episodes_to_avg):
             print(f'<------- Displaying logs at the frame {total_interactions}, episode {episode_cnt} ------->')
 
             # printing training logs

--- a/train_log.py
+++ b/train_log.py
@@ -42,6 +42,6 @@ def plot_logs(game_id, total_interactions, episode_cnt, history_of_total_losses,
 
     plt.tight_layout()
 
-    plot_path = f'{plot_dir_path}plot_{game_id.replace("/", "-")}_it_{total_interactions}'
+    plot_path = f'{plot_dir_path}log_plot_it_{total_interactions}'
     plt.savefig(plot_path)
     plt.show()

--- a/wrappers.py
+++ b/wrappers.py
@@ -1,7 +1,6 @@
 import numpy as np
 import gymnasium as gym
 from PIL import Image
-from ale_py import ALEInterface
 
 
 class AtariImage(gym.Wrapper):


### PR DESCRIPTION
Changes in this wrapping includes:
1. Directory Creation of the Project:
1.1. Put `create_proj_dirs` in a separate .py for better modulation.
1.2. Separated checkpoints that correspond to best evaluation scores we get in a separate folder `best_checkpoints_dirname` from ordinary checkpoints. 
1.3. Better naming of the saved files in some cases; e.g. added mean reward to the best saved models .

2. Completion of `requirements.txt` + Removing unnecessary imports in the files.

3. Improve logging:
3.1. Removed `scaling factor` in `train.py`.
3.2. Replaced _Frame_ by _Iteration_ in the logs for consistent naming.

4. Testing: Fix default wrappers and settings used for initializtion of test.

**NOTE:**
All of the changes are applied on top of the settings we had by the end of _Aug 10_. More specifically the didn't have frame skipping fix, Change of hyperparameters of the optimizer to something other than what's provided in the paper, or applying gradient clipping; those are applied on the test branches  